### PR TITLE
Add qb-target ped to buy scanner.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,15 @@
 Config = {}
 
+Config.Model = `u_m_y_dancerave_01`
+
+Config.PedSpawn = vec4(-1526.77, -1181.94, -0.36, 312.39)
+
+Config.PedBlip = true -- Adds a blip for the ped you purchase the scanner from.
+
+Config.ScannerFee = true -- Set to false if you want the scanner to be FREE.
+
+Config.ScannerPrice = 750 -- $750 from the player's bank.
+
 Config.minRolls = 1
 Config.maxRolls = 3
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,14 +2,15 @@ fx_version 'cerulean'
 game 'gta5'
 
 author 'Glowie'
-description 'Tresure hunting script using digiscanner'
+description 'Treasure hunting script using digiscanner'
 version '1.0'
+
+shared_script 'config.lua'
 
 client_script 'client.lua'
 
 server_scripts {
 	'server.lua',
-	'config.lua'
 }
 
 lua54 'yes'

--- a/server.lua
+++ b/server.lua
@@ -38,7 +38,7 @@ RegisterNetEvent("glow_treasure_sv:buyScanner", function()
             QBCore.Functions.Notify(src, "You purchased a scanner for $"..Config.ScannerPrice, "success")
             TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items["digiscanner"], "add")
         else
-            QBCore.Functions.Notify(src, "You need $"..Config.ScannerPrice.." to purchase this.", "success")
+            QBCore.Functions.Notify(src, "You need $"..Config.ScannerPrice.." to purchase this.", "error")
         end
     else
         local info = GenerateScannerMetadata()

--- a/server.lua
+++ b/server.lua
@@ -24,6 +24,30 @@ QBCore.Commands.Add("givescanner", "Give Player Treasure Scanner (Admin Only)", 
 
 end, "admin")
 
+RegisterNetEvent("glow_treasure_sv:buyScanner", function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    local PlyPos = GetEntityCoords(GetPlayerPed(src))
+    local bankBalance = Player.PlayerData.money.bank
+    if #(PlyPos - Config.PedSpawn.xyz) > 5.0 then return end
+    if not Player then return end
+    if Config.ScannerFee then
+        if bankBalance >= Config.ScannerPrice then
+            local info = GenerateScannerMetadata()
+            Player.Functions.AddItem("digiscanner", 1, nil, info)
+            QBCore.Functions.Notify(src, "You purchased a scanner for $"..Config.ScannerPrice, "success")
+            TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items["digiscanner"], "add")
+        else
+            QBCore.Functions.Notify(src, "You need $"..Config.ScannerPrice.." to purchase this.", "success")
+        end
+    else
+        local info = GenerateScannerMetadata()
+        Player.Functions.AddItem("digiscanner", 1, nil, info)
+        QBCore.Functions.Notify(src, "You received a scanner.", "success")
+        TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items["digiscanner"], "add")
+    end
+end)
+
 QBCore.Functions.CreateUseableItem("digiscanner", function(source, item)
     if item.info == nil or item.info.location == nil then 
         QBCore.Functions.Notify(source, "Item metadata error", "error")


### PR DESCRIPTION
#] Adds a target ped with animation to purchase scanner from.
#] Secure server event.
#] Newb-friendly config options for the purchase of the scanner.
#] Fix typo in fxmanifest and made 'config.lua' a shared script.